### PR TITLE
Formのバリデーションのバグを修正

### DIFF
--- a/src/components/Form/ExpenseInputForm.tsx
+++ b/src/components/Form/ExpenseInputForm.tsx
@@ -12,7 +12,14 @@ const expenseSchema = z
     expense: z.coerce
       .number()
       .positive({ message: "支出は正の数を入力してください" }),
-    date: z.date(),
+    date: z.date({
+      errorMap: (issue, { defaultError }) => ({
+        message:
+          issue.code === "invalid_date"
+            ? "日付を入力してください"
+            : defaultError,
+      }),
+    }),
     label: z.string().min(1, { message: "1文字以上入力してください" }),
   })
   .refine(

--- a/src/components/Form/IncomeInputForm.tsx
+++ b/src/components/Form/IncomeInputForm.tsx
@@ -5,18 +5,31 @@ import { v4 as uuidv4 } from "uuid";
 
 import { useAppSelector } from "../../store/slice/Hooks/hooks";
 import { setFinanceData } from "../../firebase/firestore/firestore-financeData-operations";
+import { formattedDateByja } from "../../utils/format";
 
 const incomeSchema = z
   .object({
     income: z.coerce
       .number()
       .positive({ message: "収入は正の数を入力してください" }),
-    date: z.date(),
+    date: z.date({
+      errorMap: (issue, { defaultError }) => ({
+        message:
+          issue.code === "invalid_date"
+            ? "日付を入力してください"
+            : defaultError,
+      }),
+    }),
   })
-  .refine((data) => data.date <= new Date(), {
-    message: `${new Date().getFullYear()}/${new Date().getMonth() + 1}/${new Date().getDate()}以前の日付を入力してください`,
-    path: ["date"],
-  });
+  .refine(
+    (data) =>
+      new Date(formattedDateByja(data.date)) <=
+      new Date(formattedDateByja(new Date())),
+    {
+      message: `${new Date().getFullYear()}/${new Date().getMonth() + 1}/${new Date().getDate()}以前の日付を入力してください`,
+      path: ["date"],
+    },
+  );
 
 type incomeInput = z.infer<typeof incomeSchema>;
 


### PR DESCRIPTION
支払い収入のフォームのバリデーション内のバグを修正
具体的には、当日の日付がバリデーションで弾かれていたため修正
また未入力の際のメッセージを日本語に変更